### PR TITLE
refactor: rename dir to source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ lint: ##@Dev Runs Qulice
 	cp target/speco-1.0-SNAPSHOT-jar-with-dependencies.jar speco.jar
 
 trans: ##@Usage Run speco on test data
-	java -jar speco.jar --dir=./tmp/xmir-in --target=./tmp/xmir-out
+	java -jar speco.jar --source=./tmp/xmir-in --target=./tmp/xmir-out
 
 trans-eo: ##@Usage Run speco on test data with --eo flag
-	java -jar speco.jar --dir=./tmp/eo-in --target=./tmp/eo-out --eo
+	java -jar speco.jar --source=./tmp/eo-in --target=./tmp/eo-out --eo
 
 run-eo: ##@Usage Compiles and runs eo program
 	cd tmp/eo-out && eoc clean && eoc link && eoc --alone dataize app && eoc clean

--- a/README.md
+++ b/README.md
@@ -111,12 +111,11 @@ $ java -jar speco.jar --help
 
 To run a transformation:
 ```bash
-$ java -jar speco.jar --dir=<input> --target=<output>
+$ java -jar speco.jar --source=<input> --target=<output>
 ```
 
-or use make commands:
+or use make command:
 ```bash
-$ make run help
 $ make trans
 ```
 

--- a/src/main/java/org/eolang/speco/Main.java
+++ b/src/main/java/org/eolang/speco/Main.java
@@ -42,7 +42,7 @@ public final class Main implements Callable<Integer> {
     /**
      * Relative path to the directory with input files.
      */
-    @CommandLine.Option(names = { "--dir" },
+    @CommandLine.Option(names = { "--source" },
         description = "Directory with input .xmir files.")
     private Path input;
 


### PR DESCRIPTION
The code uses the naming of the logical pair "source-target", so I renamed the command line parameter `--dir` to `--source` for consistency

Issue #34 