### PR TITLE
Tests refactoring

### DIFF
--- a/src/main/java/org/eolang/speco/Speco.java
+++ b/src/main/java/org/eolang/speco/Speco.java
@@ -67,14 +67,14 @@ final class Speco {
     /**
      * Ctor.
      *
-     * @param in Path to the directory with input files
+     * @param inp Path to the directory with input files
      * @param out Path to the directory with output files
-     * @param eo Iff the input program is in EO
+     * @param eolang Iff the input program is in EO
      */
-    Speco(final Path in, final Path out, final boolean eo) {
-        this.input = in.toAbsolutePath();
+    Speco(final Path inp, final Path out, final boolean eolang) {
+        this.input = inp.toAbsolutePath();
         this.output = out.toAbsolutePath();
-        this.eolang = eo;
+        this.eolang = eolang;
     }
 
     /**

--- a/src/main/java/org/eolang/speco/Speco.java
+++ b/src/main/java/org/eolang/speco/Speco.java
@@ -67,14 +67,14 @@ final class Speco {
     /**
      * Ctor.
      *
-     * @param input Path to the directory with input files
-     * @param output Path to the directory with output files
-     * @param eolang Iff the input program is in EO
+     * @param in Path to the directory with input files
+     * @param out Path to the directory with output files
+     * @param eo Iff the input program is in EO
      */
-    Speco(final Path input, final Path output, final boolean eolang) {
-        this.input = input.toAbsolutePath();
-        this.output = output.toAbsolutePath();
-        this.eolang = eolang;
+    Speco(final Path in, final Path out, final boolean eo) {
+        this.input = in.toAbsolutePath();
+        this.output = out.toAbsolutePath();
+        this.eolang = eo;
     }
 
     /**
@@ -82,10 +82,10 @@ final class Speco {
      *
      * @throws IOException In case of errors when working with files or parsing a document
      */
-    public void exec() throws IOException {
+    void exec() throws IOException {
         final Path source;
         if (this.eolang) {
-            source = parse(this.input);
+            source = Speco.parse(this.input);
         } else {
             source = this.input;
         }
@@ -114,7 +114,7 @@ final class Speco {
      * @param xml XML
      * @return XML
      */
-    public static XML applyTrain(final XML xml) {
+    private static XML applyTrain(final XML xml) {
         final Train<Shift> train = new TrDefault<Shift>()
             .with(new StClasspath("/org/eolang/speco/1-1-coping.xsl"))
             .with(new StEndless(new StClasspath("/org/eolang/speco/1-2-specialization.xsl")))
@@ -137,7 +137,7 @@ final class Speco {
         for (final Path path : Files.newDirectoryStream(source)) {
             new Syntax(
                 "scenario",
-                new InputOf(String.format("%s\n", Files.readString(path))),
+                new InputOf(String.format("%s%n", Files.readString(path))),
                 new OutputTo(new FileOutputStream(path.toFile()))
             ).parse();
         }

--- a/src/test/java/org/eolang/speco/AllTransformationStepsTest.java
+++ b/src/test/java/org/eolang/speco/AllTransformationStepsTest.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Objectionary
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.speco;
+
+import org.eolang.jucs.ClasspathSource;
+import org.eolang.xax.XaxStory;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+
+/**
+ * The tests check that the transformations are performed correctly on XMIR.
+ * Each test check separate transformation of the Speco algorithm.
+ *
+ * @since 0.2
+ */
+@Tag("fast")
+class AllTransformationStepsTest {
+
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/speco/transformations", glob = "**.yaml")
+    void appliesTransformationsToXmir(final String pack) {
+        MatcherAssert.assertThat(
+            new XaxStory(pack),
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/test/java/org/eolang/speco/SpecoEoTest.java
+++ b/src/test/java/org/eolang/speco/SpecoEoTest.java
@@ -41,47 +41,19 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.yaml.snakeyaml.Yaml;
 
 /**
- * Packs tests.
+ * Tests that check entire Speco algorithm applied directly to raw EO programs.
  *
  * @since 0.0.1
  */
-class SpecoTest {
+class SpecoEoTest {
 
     /**
      * The number of lines that the command "eoc link" outputs.
      */
     private static final int INTENT = 11;
-
-    @Tag("fast")
-    @ParameterizedTest
-    @ValueSource(strings = {"simple"})
-    void convertsFromXmir(final String title, @TempDir final Path out) throws IOException {
-        final Path base = Path.of(
-            "src", "test", "resources",
-            "org", "eolang", "speco",
-            "xmir", title
-        );
-        new Speco(base.resolve("in"), out, false).exec();
-        final Path expected = base.resolve("out");
-        for (final Path path : Files.newDirectoryStream(expected)) {
-            MatcherAssert.assertThat(
-                String.format(
-                    "Files %s in %s and %s are different",
-                    path.getFileName(),
-                    out,
-                    expected
-                ),
-                Files.readAllLines(out.resolve(path.getFileName())),
-                Matchers.equalTo(
-                    Files.readAllLines(path)
-                )
-            );
-        }
-    }
 
     /**
      * Integration test for conversation from EO.
@@ -97,7 +69,7 @@ class SpecoTest {
         final Map<String, Object> script = new Yaml().load(pack);
         MatcherAssert.assertThat(
             "Unexpected transformation result",
-            Files.readString(SpecoTest.run(script, temp).resolve("app.eo")),
+            Files.readString(SpecoEoTest.run(script, temp).resolve("app.eo")),
             Matchers.equalTo(script.get("after").toString())
         );
     }
@@ -110,7 +82,7 @@ class SpecoTest {
      *  or get rid of the @TempDir.
      * @param pack Pack this test data
      * @param temp Temporary test dir
-     * @throws IOException Iff IO error
+     * @throws java.io.IOException Iff IO error
      */
     @Tag("slow")
     @DisabledOnOs(OS.WINDOWS)
@@ -121,7 +93,7 @@ class SpecoTest {
         final Map<String, Object> script = new Yaml().load(pack);
         MatcherAssert.assertThat(
             "Unexpected execution result",
-            SpecoTest.dataize(SpecoTest.run(script, temp).toString()),
+            SpecoEoTest.dataize(SpecoEoTest.run(script, temp).toString()),
             Matchers.equalTo(
                 script.get("result").toString().split("\\r?\\n")
             )
@@ -141,9 +113,9 @@ class SpecoTest {
         final Path input = temp.resolve("input");
         final Path output = temp.resolve("output");
         Files.createDirectories(input);
-        Files.write(
+        Files.writeString(
             input.resolve("app.eo"),
-            script.get("before").toString().getBytes(),
+            script.get("before").toString(),
             StandardOpenOption.CREATE
         );
         new Speco(input, output, true).exec();
@@ -179,6 +151,6 @@ class SpecoTest {
         process.destroy();
         final String[] output = writer.toString().split("\\r?\\n");
         writer.close();
-        return Arrays.copyOfRange(output, SpecoTest.INTENT, output.length - 1);
+        return Arrays.copyOfRange(output, SpecoEoTest.INTENT, output.length - 1);
     }
 }

--- a/src/test/java/org/eolang/speco/SpecoTest.java
+++ b/src/test/java/org/eolang/speco/SpecoTest.java
@@ -60,23 +60,23 @@ class SpecoTest {
     @Tag("fast")
     @ParameterizedTest
     @ValueSource(strings = {"simple"})
-    void convertsFromXmir(final String title, @TempDir final Path temp) throws IOException {
+    void convertsFromXmir(final String title, @TempDir final Path out) throws IOException {
         final Path base = Path.of(
             "src", "test", "resources",
             "org", "eolang", "speco",
             "xmir", title
         );
-        new Speco(base.resolve("in"), temp, false).exec();
-        final Path reference = base.resolve("out");
-        for (final Path path : Files.newDirectoryStream(reference)) {
+        new Speco(base.resolve("in"), out, false).exec();
+        final Path expected = base.resolve("out");
+        for (final Path path : Files.newDirectoryStream(expected)) {
             MatcherAssert.assertThat(
                 String.format(
                     "Files %s in %s and %s are different",
                     path.getFileName(),
-                    temp,
-                    reference
+                    out,
+                    expected
                 ),
-                Files.readAllLines(temp.resolve(path.getFileName())),
+                Files.readAllLines(out.resolve(path.getFileName())),
                 Matchers.equalTo(
                     Files.readAllLines(path)
                 )
@@ -99,9 +99,7 @@ class SpecoTest {
         MatcherAssert.assertThat(
             "Unexpected transformation result",
             Files.readString(SpecoTest.run(script, temp).resolve("app.eo")),
-            Matchers.equalTo(
-                script.get("after").toString()
-            )
+            Matchers.equalTo(script.get("after").toString())
         );
     }
 

--- a/src/test/java/org/eolang/speco/SpecoTest.java
+++ b/src/test/java/org/eolang/speco/SpecoTest.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.eolang.jucs.ClasspathSource;
-import org.eolang.xax.XaxStory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Tag;
@@ -126,20 +125,6 @@ class SpecoTest {
             Matchers.equalTo(
                 script.get("result").toString().split("\\r?\\n")
             )
-        );
-    }
-
-    /**
-     * Unit tests for transformations.
-     * @param pack Pack with test data
-     */
-    @Tag("fast")
-    @ParameterizedTest
-    @ClasspathSource(value = "org/eolang/speco/transformations", glob = "**.yaml")
-    void applyTransToXmir(final String pack) {
-        MatcherAssert.assertThat(
-            new XaxStory(pack),
-            Matchers.is(true)
         );
     }
 

--- a/src/test/java/org/eolang/speco/SpecoTest.java
+++ b/src/test/java/org/eolang/speco/SpecoTest.java
@@ -23,12 +23,6 @@
  */
 package org.eolang.speco;
 
-import com.jcabi.xml.XMLDocument;
-import com.yegor256.xsline.Shift;
-import com.yegor256.xsline.StClasspath;
-import com.yegor256.xsline.TrDefault;
-import com.yegor256.xsline.Train;
-import com.yegor256.xsline.Xsline;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
@@ -66,7 +60,7 @@ class SpecoTest {
     @Tag("fast")
     @ParameterizedTest
     @ValueSource(strings = {"simple"})
-    public void convertsFromXmir(final String title, @TempDir final Path temp) throws IOException {
+    void convertsFromXmir(final String title, @TempDir final Path temp) throws IOException {
         final Path base = Path.of(
             "src", "test", "resources",
             "org", "eolang", "speco",
@@ -100,7 +94,7 @@ class SpecoTest {
     @DisabledOnOs(OS.WINDOWS)
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/speco/packs", glob = "**.yaml")
-    public void convertsFromEo(final String pack, @TempDir final Path temp) throws IOException {
+    void convertsFromEo(final String pack, @TempDir final Path temp) throws IOException {
         final Map<String, Object> script = new Yaml().load(pack);
         MatcherAssert.assertThat(
             "Unexpected transformation result",
@@ -125,7 +119,7 @@ class SpecoTest {
     @DisabledOnOs(OS.WINDOWS)
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/speco/packs", glob = "**.yaml")
-    public void compilesFromEo(final String pack, @TempDir final Path temp)
+    void compilesFromEo(final String pack, @TempDir final Path temp)
         throws IOException, InterruptedException {
         final Map<String, Object> script = new Yaml().load(pack);
         MatcherAssert.assertThat(
@@ -140,12 +134,11 @@ class SpecoTest {
     /**
      * Unit tests for transformations.
      * @param pack Pack with test data
-     * @throws IOException Iff IO error
      */
     @Tag("fast")
     @ParameterizedTest
     @ClasspathSource(value = "org/eolang/speco/transformations", glob = "**.yaml")
-    public void applyTransToXmir(final String pack) throws IOException {
+    void applyTransToXmir(final String pack) {
         MatcherAssert.assertThat(
             new XaxStory(pack),
             Matchers.is(true)
@@ -175,12 +168,12 @@ class SpecoTest {
     }
 
     /**
-    * Compiles and dataize EO program.
-    *
-    * @param target Path to the dir with target EO program
-    * @return List of lines in output
-    * @throws IOException Iff IO error
-    */
+     * Compiles and dataize EO program.
+     *
+     * @param target Path to the dir with target EO program
+     * @return List of lines in output
+     * @throws IOException Iff IO error
+     */
     private static String[] dataize(final String target) throws IOException, InterruptedException {
         final String executor;
         final String flag;

--- a/src/test/java/org/eolang/speco/SpecoXmirTest.java
+++ b/src/test/java/org/eolang/speco/SpecoXmirTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022 Objectionary
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.speco;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests that check entire Speco algorithm applied directly to parsed XMIR.
+ *
+ * @since 0.2
+ */
+class SpecoXmirTest {
+
+    @Tag("fast")
+    @ParameterizedTest
+    @ValueSource(strings = "simple")
+    void convertsFromXmir(final String title, @TempDir final Path out) throws IOException {
+        final Path base = Path.of(
+            "src", "test", "resources",
+            "org", "eolang", "speco",
+            "xmir", title
+        );
+        new Speco(base.resolve("in"), out, false).exec();
+        final Path expected = base.resolve("out");
+        for (final Path path : Files.newDirectoryStream(expected)) {
+            MatcherAssert.assertThat(
+                String.format(
+                    "Files %s in %s and %s are different",
+                    path.getFileName(),
+                    out,
+                    expected
+                ),
+                Files.readAllLines(out.resolve(path.getFileName())),
+                Matchers.equalTo(
+                    Files.readAllLines(path)
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
Here are the changes made:

1. The Speco test has been divided into three separate tests:
1.1. `AllTransformationStepsTest`
1.2. `SpecoEoTest`
1.3. `SpecoXmirTest`
2. Some minor fixes have been applied, such as renaming variables and restricting the visibility of certain methods.