### PR TITLE
tests for rule 4

### DIFF
--- a/src/main/resources/org/eolang/speco/4-1-fence-tuples.xsl
+++ b/src/main/resources/org/eolang/speco/4-1-fence-tuples.xsl
@@ -25,10 +25,6 @@ SOFTWARE.
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="SG" version="2.0">
   <!--
     Rule #4: extend the program by creating duplicates of each fence attribute.
-    @todo #68:30min add unit-test for transformation,
-     in which the input will be xmir with object with fence attribute,
-     the expected result will be the same xmir with a *-as-tuple attribute
-     for this fence attribute.
   -->
   <xsl:output indent="yes" method="xml"/>
   <xsl:strip-space elements="*"/>

--- a/src/main/resources/org/eolang/speco/4-1-fence-tuples.xsl
+++ b/src/main/resources/org/eolang/speco/4-1-fence-tuples.xsl
@@ -55,10 +55,10 @@ SOFTWARE.
                   <xsl:for-each select="o[last()]">
                     <xsl:element name="o">
                       <xsl:attribute name="base">
-                        <xsl:value-of select="'array'"/>
+                        <xsl:value-of select="'tuple'"/>
                       </xsl:attribute>
                       <xsl:attribute name="data">
-                        <xsl:value-of select="'array'"/>
+                        <xsl:value-of select="'tuple'"/>
                       </xsl:attribute>
                       <xsl:copy-of select="."/>
                       <xsl:element name="o">

--- a/src/test/resources/org/eolang/speco/packs/examples/counter.yaml
+++ b/src/test/resources/org/eolang/speco/packs/examples/counter.yaml
@@ -1,0 +1,210 @@
+before: |
+  [s] > counter
+    memory > k
+      s
+    [] > next
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        ^
+        .k
+  [] > app
+    counter > c
+      0
+    c
+    .next > x1
+    c
+    .next > x2
+    c
+    .next > x3
+    seq > @
+      QQ
+      .io
+      .stdout
+        QQ
+        .txt
+        .sprintf
+          "First: %d\nSecond: %d\nThird: %d\n"
+          x1
+          x2
+          x3
+
+after: |
+  [s] > counter
+    memory > k
+      s
+    [] > next
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        ^
+        .k
+    [s] > with_counter
+      counter_spec_s_counter > @
+        s
+    [s] > with_counter_next
+      counter_spec_s_counter_next > @
+        s
+    [s] > with_app
+      counter_spec_s_app > @
+        s
+    [] > next_as_tuple
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        *
+          ^
+          .k
+          ^
+  
+  [] > app
+    counter > c
+      0
+    c
+    .next > x1
+    c
+    .next > x2
+    c
+    .next > x3
+    seq > @
+      QQ
+      .io
+      .stdout
+        QQ
+        .txt
+        .sprintf
+          "First: %d\nSecond: %d\nThird: %d\n"
+          x1
+          x2
+          x3
+  
+  [s] > counter_spec_s_counter
+    memory > k
+      s
+    [] > next
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        ^
+        .k
+    [s] > with_counter
+      counter_spec_s_counter > @
+        s
+    [s] > with_counter_next
+      counter_spec_s_counter_next > @
+        s
+    [s] > with_app
+      counter_spec_s_app > @
+        s
+    [] > next_as_tuple
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        *
+          ^
+          .k
+          ^
+  
+  [s] > counter_spec_s_counter_next
+    memory > k
+      s
+    [] > next
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        ^
+        .k
+    [s] > with_counter
+      counter_spec_s_counter > @
+        s
+    [s] > with_counter_next
+      counter_spec_s_counter_next > @
+        s
+    [s] > with_app
+      counter_spec_s_app > @
+        s
+    [] > next_as_tuple
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        *
+          ^
+          .k
+          ^
+  
+  [s] > counter_spec_s_app
+    memory > k
+      s
+    [] > next
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        ^
+        .k
+    [s] > with_counter
+      counter_spec_s_counter > @
+        s
+    [s] > with_counter_next
+      counter_spec_s_counter_next > @
+        s
+    [s] > with_app
+      counter_spec_s_app > @
+        s
+    [] > next_as_tuple
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        *
+          ^
+          .k
+          ^
+
+result: |
+  First: 1
+  Second: 2
+  Third: 3

--- a/src/test/resources/org/eolang/speco/transformations/4-1-fence-tuples.yaml
+++ b/src/test/resources/org/eolang/speco/transformations/4-1-fence-tuples.yaml
@@ -33,4 +33,4 @@ document:
     <speco/>
   </program>
 asserts:
-  - /program/objects/o/o[@fence="next" and @name="next_as_tuple"]/o/o[last() and @base="array" and @data="array"]/o[last() and @base="^"]
+  - /program/objects/o/o[@fence="next" and @name="next_as_tuple"]/o/o[last() and @base="tuple" and @data="tuple"]/o[last() and @base="^"]

--- a/src/test/resources/org/eolang/speco/transformations/4-1-fence-tuples.yaml
+++ b/src/test/resources/org/eolang/speco/transformations/4-1-fence-tuples.yaml
@@ -1,0 +1,36 @@
+sheets:
+  - /org/eolang/speco/4-1-fence-tuples.xsl
+document:
+  <?xml version="1.0" encoding="UTF-8"?>
+    <program>
+    <listing/>
+    <errors/>
+    <sheets/>
+    <objects>
+      <o abstract="" line="1" name="counter" pos="0">
+        <o line="1" name="s" pos="1"/>
+        <o base="memory" line="2" name="k" pos="2">
+          <o base="s" line="3" pos="4"/>
+        </o>
+        <o abstract="" line="4" name="next" pos="2">
+          <o base="seq" line="5" name="@" pos="4">
+            <o base="^" line="6" pos="6"/>
+            <o base=".k" line="7" method="" pos="6"/>
+            <o base=".write" line="8" method="" pos="6">
+              <o base="^" line="9" pos="8"/>
+              <o base=".k" line="10" method="" pos="8"/>
+              <o base=".plus" line="11" method="" pos="8">
+                <o base="int" data="bytes" line="12" pos="10">00 00 00 00 00 00 00 01</o>
+              </o>
+            </o>
+            <o base="^" line="13" pos="6"/>
+            <o base=".k" line="14" method="" pos="6"/>
+          </o>
+        </o>
+      </o>
+    </objects>
+    <aoi/>
+    <speco/>
+  </program>
+asserts:
+  - /program/objects/o/o[@fence="next" and @name="next_as_tuple"]/o/o[last() and @base="array" and @data="array"]/o[last() and @base="^"]


### PR DESCRIPTION
Add `xmir` unit test for `4-1-fence-tuples.xsl` transformation and `eo` unit and compilation test with `counter`. Closes #80. 

23 tests passes now.