### PR TITLE
docs: renovate readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Rule 4:
 * Create copies of these attributes, modifying them so that tuple with the object it returned before and the "parent" object is returned.
 
 Rule 5:
-* Replace accessing the parent object with creating an intermediate tuple object and getting its first element.
+* Replace accessing the "parent" object with creating an intermediate tuple object and getting its first element.
 
 Rule 6:
 * Replace calls of the "parent" object (all except the first one) with calls of the second elements of intermediate tuples in the order in the program. Later this should be replaced by using EOG.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,6 @@ or use make command:
 $ make trans
 ```
 
-TODO: add flags docs
-
 ## How it works
 
 The tool works according to an algorithm consisting of 7 transformation rules.
@@ -143,7 +141,17 @@ Rule 3:
 * For each object, for each of its specialized/polymorphic versions, create a `with-*` attribute that would returns a new object for the current version. The current state of the object should be deeply copied into the new object.
 
 Rule 4:
+* Search for all fence attributes, that reference to the `memory` wrapper object;
+* Create copies of these attributes, modifying them so that tuple with the object it returned before and the "parent" object is returned.
 
+Rule 5:
+* Replace accessing the parent object with creating an intermediate tuple object and getting its first element.
+
+Rule 6:
+* Replace calls of the "parent" object (all except the first one) with calls of the second elements of intermediate tuples in the order in the program. Later this should be replaced by using EOG.
+
+Rule 7:
+* Modify the `*-as-tuple` attribute so that it returns a new object instead of changing itself by using the `with-*` attribute.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Specialization of objects in EO programs.
 
-SPECO is a tool that is aimed to be launched on the EO program converted to a collection of .xmir files,
+**Speco** is a tool that is aimed to be launched on the EO program converted to a collection of .xmir files,
 which has undergone modifications performed by [AOI](https://github.com/objectionary/aoi) tool.
 
 Consider the following EO program:
@@ -75,21 +75,21 @@ It does not give any hints on what object `x` may be in this context.
 </o>
 ```
 
-SPECO makes it obvious what `x` is in the provided context. For example, it will turn object `pet1`
-into these two declarations of objects `pet1_spec_x=cat` and `pet1_spec_x=dog`, which are specific
+**Speco** makes it obvious what `x` is in the provided context. For example, it will turn object `pet1`
+into these two declarations of objects `pet1_spec_x_cat` and `pet1_spec_x_dog`, which are specific
 for `cat` and `dog` correspondingly.
 
 ```
-<o abstract="" line="20" name="pet1_spec_x=cat" pos="0">
-   <o line="20" name="x" pos="1" spec="cat"/>
+<o abstract="" line="20" name="pet1_spec_x_cat" pos="0" spec="pet1">
+   <o line="20" name="x" pos="1"/>
    <o base="x" line="21" pos="2"/>
    <o base=".talk" line="21" name="@" pos="3"/>
 </o>
 ```
 
 ```
-<o abstract="" line="20" name="pet1_spec_x=dog" pos="0">
-   <o line="20" name="x" pos="1" spec="dog"/>
+<o abstract="" line="20" name="pet1_spec_x_dog" pos="0" spec="pet1">
+   <o line="20" name="x" pos="1"/>
    <o base="x" line="21" pos="2"/>
    <o base=".talk" line="21" name="@" pos="3"/>
 </o>
@@ -114,10 +114,20 @@ To run a transformation:
 $ java -jar speco.jar --source=<input> --target=<output>
 ```
 
-or use make command:
+or use make command for `.xmir`:
 ```bash
 $ make trans
 ```
+
+## How it works
+
+### Transformations
+
+TODO: specification of each transformation
+
+### Project Structure
+
+TODO: about classes and functions (if it is developer guide, then there are good comments, if user guide, then it should be in Usage)
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Consider the following EO program:
     x.eat
 ```
 
-The following block in the .xmir file of this program will be generated after AOI launch:
+The following block in the `.xmir` file of this program will be generated after AOI launch:
 
 ```
 <aoi>
@@ -95,7 +95,7 @@ for `cat` and `dog` correspondingly.
 </o>
 ```
 
-It will generate a collection of modified .xmir files as an output.
+It will generate a collection of modified `.xmir` files as an output.
 
 ## Usage
 
@@ -114,20 +114,36 @@ To run a transformation:
 $ java -jar speco.jar --source=<input> --target=<output>
 ```
 
-or use make command for `.xmir`:
+or use make command:
 ```bash
 $ make trans
 ```
 
+TODO: add flags docs
+
 ## How it works
 
-### Transformations
+The tool works according to an algorithm consisting of 7 transformation rules.
 
-TODO: specification of each transformation
+Rule 1:
+* Create a `<speco/>` node consisting of specialized `<versions/>` nodes for all objects inferred by AOI;
+* Each node has attributes:
+  * `@name` -- name of the polymorphic object,
+  * `@var` -- name of the polymorphic attribute of this object,
+  * `@spec` -- name of the object that specializes this attribute;
+* Each node consists of a single object copied from the `<objects/>` node by name `@name`, but also changed attributes:
+  * `@name` replaced by `@name_spec_@var_@spec`
+  * `@spec` equal `version@spec`
+* Copy all specialized objects (content of the `<version/>` node) to the `<objects/>` node.
 
-### Project Structure
+Rule 2:
+* For all applications: if there is a polymorphic base object and a specialized version is uniquely determined, then a replacement to determined version occurs.
 
-TODO: about classes and functions (if it is developer guide, then there are good comments, if user guide, then it should be in Usage)
+Rule 3:
+* For each object, for each of its specialized/polymorphic versions, create a `with-*` attribute that would returns a new object for the current version. The current state of the object should be deeply copied into the new object.
+
+Rule 4:
+
 
 ## How to Contribute
 


### PR DESCRIPTION
Update `README.md`, add specification of transformations. Closes #45 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR renames SPECO to **Speco** in the README and provides a comprehensive list of changes, including a new "How it works" section with a 7-rule algorithm. 

### Detailed summary
- Renamed SPECO to **Speco**
- Added a new "How it works" section with a 7-rule algorithm 
- Updated usage instructions 
- General text improvements and code formatting 
- No files skipped

<!-- end pr-codex -->