### PR TITLE
fix bug with tuples

### DIFF
--- a/src/main/resources/org/eolang/speco/7-1-substitute-returned.xsl
+++ b/src/main/resources/org/eolang/speco/7-1-substitute-returned.xsl
@@ -36,6 +36,7 @@ SOFTWARE.
   -->
   <xsl:template match="/program/objects//o[../../@fence and @base='tuple']/o[1]">
     <xsl:for-each select="../../o[@base='.write']/o[1]">
+      <xsl:variable name="name" select="../../../../@name"/>
       <xsl:copy>
         <xsl:attribute name="base">
           <xsl:value-of select="concat(substring-after(@base, '.'), '.')"/>
@@ -43,7 +44,7 @@ SOFTWARE.
         <xsl:apply-templates select="@* except @base"/>
         <xsl:element name="o">
           <xsl:attribute name="base">
-            <xsl:value-of select="concat('.', ../../../../o[starts-with(@name, 'with_')][1]/@name)"/>
+            <xsl:value-of select="concat('.', ../../../../o[starts-with(@name, 'with_') and o/@base=$name or @name=concat('with_', $name)]/@name)"/>
           </xsl:attribute>
           <xsl:attribute name="name">
             <xsl:value-of select="'tmp'"/>

--- a/src/test/resources/org/eolang/speco/packs/examples/counter-fake-int.yaml
+++ b/src/test/resources/org/eolang/speco/packs/examples/counter-fake-int.yaml
@@ -1,4 +1,5 @@
 before: |
+  [x] > fake_int
   [s] > counter
     memory > k
       s
@@ -35,6 +36,20 @@ before: |
           x3
 
 after: |
+  [x] > fake_int
+    [x] > with_fake_int
+      fake_int_spec_x_fake_int > @
+        x
+    [x] > with_counter
+      fake_int_spec_x_counter > @
+        x
+    [x] > with_counter_next
+      fake_int_spec_x_counter_next > @
+        x
+    [x] > with_app
+      fake_int_spec_x_app > @
+        x
+  
   [s] > counter
     memory > k
       s
@@ -49,6 +64,9 @@ after: |
             1
         ^
         .k
+    [s] > with_fake_int
+      counter_spec_s_fake_int > @
+        s
     [s] > with_counter
       counter_spec_s_counter > @
         s
@@ -105,6 +123,101 @@ after: |
           x2
           x3
   
+  [x] > fake_int_spec_x_fake_int
+    [x] > with_fake_int
+      fake_int_spec_x_fake_int > @
+        x
+    [x] > with_counter
+      fake_int_spec_x_counter > @
+        x
+    [x] > with_counter_next
+      fake_int_spec_x_counter_next > @
+        x
+    [x] > with_app
+      fake_int_spec_x_app > @
+        x
+  
+  [x] > fake_int_spec_x_counter
+    [x] > with_fake_int
+      fake_int_spec_x_fake_int > @
+        x
+    [x] > with_counter
+      fake_int_spec_x_counter > @
+        x
+    [x] > with_counter_next
+      fake_int_spec_x_counter_next > @
+        x
+    [x] > with_app
+      fake_int_spec_x_app > @
+        x
+  
+  [x] > fake_int_spec_x_counter_next
+    [x] > with_fake_int
+      fake_int_spec_x_fake_int > @
+        x
+    [x] > with_counter
+      fake_int_spec_x_counter > @
+        x
+    [x] > with_counter_next
+      fake_int_spec_x_counter_next > @
+        x
+    [x] > with_app
+      fake_int_spec_x_app > @
+        x
+  
+  [x] > fake_int_spec_x_app
+    [x] > with_fake_int
+      fake_int_spec_x_fake_int > @
+        x
+    [x] > with_counter
+      fake_int_spec_x_counter > @
+        x
+    [x] > with_counter_next
+      fake_int_spec_x_counter_next > @
+        x
+    [x] > with_app
+      fake_int_spec_x_app > @
+        x
+  
+  [s] > counter_spec_s_fake_int
+    memory > k
+      s
+    [] > next
+      seq > @
+        ^
+        .k
+        .write
+          ^
+          .k
+          .plus
+            1
+        ^
+        .k
+    [s] > with_fake_int
+      counter_spec_s_fake_int > @
+        s
+    [s] > with_counter
+      counter_spec_s_counter > @
+        s
+    [s] > with_counter_next
+      counter_spec_s_counter_next > @
+        s
+    [s] > with_app
+      counter_spec_s_app > @
+        s
+    [] > next_as_tuple
+      seq > @
+        TRUE
+        *
+          k.
+            ^
+            .with_fake_int > tmp
+              ^
+              .k
+              .plus
+                1
+          tmp
+  
   [s] > counter_spec_s_counter
     memory > k
       s
@@ -119,6 +232,9 @@ after: |
             1
         ^
         .k
+    [s] > with_fake_int
+      counter_spec_s_fake_int > @
+        s
     [s] > with_counter
       counter_spec_s_counter > @
         s
@@ -155,6 +271,9 @@ after: |
             1
         ^
         .k
+    [s] > with_fake_int
+      counter_spec_s_fake_int > @
+        s
     [s] > with_counter
       counter_spec_s_counter > @
         s
@@ -191,6 +310,9 @@ after: |
             1
         ^
         .k
+    [s] > with_fake_int
+      counter_spec_s_fake_int > @
+        s
     [s] > with_counter
       counter_spec_s_counter > @
         s


### PR DESCRIPTION
Fixes bug, fixes old tests, add a new test with "fake int counter" (afaik AOI cannot work with nested objects or atoms now, so I add a wrapper for `int` to test replacement with specialized version based on type). Closes #101.