### PR TITLE
fix: exclude dep version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
     <dependency>
       <groupId>org.eolang</groupId>
       <artifactId>eo-parser</artifactId>
-      <version>0.29.1</version>
+      <version>0.29.3</version>
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>
@@ -206,7 +206,7 @@ SOFTWARE.
                 <exclude>dependencies:org.eolang</exclude>
                 <exclude>dependencies:com.yegor256:xsline:jar:0.13.0:compile</exclude>
                 <exclude>dependencies:org.apache.commons:commons-lang3:jar:3.12.0:compile</exclude>
-                <exclude>dependencies:org.yaml:snakeyaml:jar:1.33:compile</exclude>
+                <exclude>dependencies:org.yaml:snakeyaml:jar:2.0:compile</exclude>
                 <exclude>duplicatefinder:.*</exclude>
               </excludes>
             </configuration>


### PR DESCRIPTION
Fixes #85

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `eo-parser` and `snakeyaml` dependencies in `pom.xml`.
### Detailed summary
- Update `eo-parser` to version `0.29.3`.
- Update `snakeyaml` to version `2.0`.

<!-- end pr-codex -->