### PR TITLE
fix .rultor.yml

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -20,20 +20,3 @@ release:
     git commit -am "${tag}"
     mvn clean install -Dinvoker.skip
     mvn clean deploy -Pobjectionary -Psonatype --errors --settings ../settings.xml -Dstyle.color=never
-
-    mkdir /tmp/objectionary
-    cp -R src/main/eo /tmp/objectionary/objects
-    cp -R src/test/eo /tmp/objectionary/tests
-    branch=$(git rev-parse --abbrev-ref HEAD)
-    git checkout gh-pages
-    git reset --hard
-    sudo git config --global --add safe.directory "$(pwd)"
-    sudo /bin/bash -c "cd '$(pwd)'; git clean -fd"
-    rm -rf objectionary
-    cp -R /tmp/objectionary .
-    find objectionary -name '*.eo' | xargs sed -i "s/0\.0\.0/${tag}/g"
-    git add objectionary
-    find objectionary -name '*.eo' > objectionary.lst
-    git add objectionary.lst
-    git commit -am "objectionary ${tag}"
-    git checkout "${branch}"


### PR DESCRIPTION
Fixes releases

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `rultor.yml` file with new deployment steps for the `objectionary` project.

### Detailed summary
- Adds a deployment step to copy `src/main/eo` and `src/test/eo` directories to `/tmp/objectionary/objects` and `/tmp/objectionary/tests` respectively.
- Adds a deployment step to checkout the `gh-pages` branch, reset it, and clean the repository.
- Adds a deployment step to copy the contents of `/tmp/objectionary` to the project root directory.
- Adds a command to find and replace all instances of `0.0.0` with `${tag}` in `.eo` files.
- Adds a deployment step to create a list of all `.eo` files in the `objectionary` directory and add it to the repository.
- Commits the changes to the `objectionary` project with the message "objectionary ${tag}".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->